### PR TITLE
Instrumented Test for PhotoBlowupFragment

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="PROJECT" charset="UTF-8" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,9 +3,8 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="distributionType" value="LOCAL" />
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleHome" value="$APPLICATION_HOME_DIR$/gradle/gradle-2.14.1" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -43,4 +43,20 @@
   <component name="ProjectType">
     <option name="id" value="Android" />
   </component>
+  <component name="masterDetails">
+    <states>
+      <state key="ProjectJDKs.UI">
+        <settings>
+          <last-edited>1.8</last-edited>
+          <splitter-proportions>
+            <option name="proportions">
+              <list>
+                <option value="0.2" />
+              </list>
+            </option>
+          </splitter-proportions>
+        </settings>
+      </state>
+    </states>
+  </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,4 +27,5 @@ dependencies {
     compile 'com.android.support:appcompat-v7:24.2.1'
     compile 'com.android.volley:volley:1.0.0'
     testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:1.10.19'
 }

--- a/app/src/androidTest/java/com/example/samplegallery/PhotoBlowupFragmentTest.java
+++ b/app/src/androidTest/java/com/example/samplegallery/PhotoBlowupFragmentTest.java
@@ -1,0 +1,140 @@
+package com.example.samplegallery;
+
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.IdlingResource;
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.util.Log;
+
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.example.samplegallery.Utilities.VolleyRequestQueue;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withResourceName;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.anything;
+import static org.hamcrest.CoreMatchers.not;
+
+/**
+ * Created by Sean Walker on 1/29/17.
+ */
+
+
+// test photo blowup synchronization
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class PhotoBlowupFragmentTest {
+    // disable the volley queue before the activity is launched to make sure that we may test
+    // the behaviour of the test both before and after the data has been pulled.
+    @Rule
+    public ActivityTestRule<MainActivity> mActivityRule =
+            new ActivityTestRule<MainActivity>(MainActivity.class) {
+
+                @Override
+                protected void beforeActivityLaunched() {
+                    super.beforeActivityLaunched();
+
+                    VolleyRequestQueue
+                            .getInstance(InstrumentationRegistry.getTargetContext().getApplicationContext())
+                            .getRequestQueue()
+                            .stop();
+                }
+            };
+    @Test
+    public void photoBlowupTest() throws Exception {
+        // register our volley request queue as an idling resource and start it.
+        VolleyQueueIdlingResource vqidr = new VolleyQueueIdlingResource("Volley Queue");
+        VolleyRequestQueue.getInstance(null).getRequestQueue().start();
+        Espresso.registerIdlingResources(vqidr);
+
+        // navigate to an album
+        onData(anything())
+                .inAdapterView(withId(R.id.albums_list_view))
+                .atPosition(0)
+                .perform(click());
+
+        // attempt to click on a photo to blow it up
+        onData(anything())
+                .inAdapterView(withId(R.id.gridview))
+                .atPosition(0)
+                .perform(click());
+
+        // the description, title, and photo itself should all be visible together
+        onView(withId(R.id.photo_blowup))
+                .check(matches(isDisplayed()));
+        onView(withResourceName("photo_description"))
+                .check(matches(isDisplayed()));
+        onView(withResourceName("photo_title"))
+                .check(matches(isDisplayed()));
+        // and the progress bar should be hidden
+        onView(withId(R.id.progress_bar_blowup))
+                .check(matches(not(isDisplayed())));
+    }
+
+    private class VolleyQueueIdlingResource implements IdlingResource {
+        private Field mCurrentRequests;
+        private String resName;
+        private volatile ResourceCallback resourceCallback;
+
+        VolleyQueueIdlingResource(String resourceName) throws NoSuchFieldException {
+            resName = resourceName;
+            mCurrentRequests = RequestQueue.class.getDeclaredField("mCurrentRequests");
+            mCurrentRequests.setAccessible(true);
+        }
+
+        @Override
+        public String getName() {
+            return resName;
+        }
+
+        @Override
+        public boolean isIdleNow() {
+            try {
+                synchronized (mCurrentRequests.get(
+                        VolleyRequestQueue.getInstance(null).getRequestQueue()
+                )) {
+                    @SuppressWarnings("unchecked")
+                    Set<Request> requests = (Set<Request>) mCurrentRequests.get(
+                            VolleyRequestQueue.getInstance(null).getRequestQueue()
+                    );
+
+                    if (requests.size() == 0) {
+                        if(resourceCallback != null) {
+                            resourceCallback.onTransitionToIdle();
+                        }
+
+                        return true;
+                    }
+
+                    return false;
+                }
+            } catch (IllegalAccessException e) {
+                Log.e("AlbumsFragmentTest", "Cannot access request queue variable!");
+                e.printStackTrace();
+                System.exit(-1);
+            }
+
+            return false;
+        }
+
+        @Override
+        public void registerIdleTransitionCallback(ResourceCallback callback) {
+            resourceCallback = callback;
+        }
+    }
+}

--- a/app/src/main/java/com/example/samplegallery/APIKeys.java
+++ b/app/src/main/java/com/example/samplegallery/APIKeys.java
@@ -10,6 +10,5 @@ package com.example.samplegallery;
  * keys publically!
  */
 public class APIKeys {
-    // TODO: Change back to bogus key
-    public static final String FLICKR_API_KEY = "42abab5d4c80cdc5db2ea7a0a2df46b9";
+    public static final String FLICKR_API_KEY = "64ffdc1fd4b18211f4f98513848d2335";
 }

--- a/app/src/main/java/com/example/samplegallery/APIKeys.java
+++ b/app/src/main/java/com/example/samplegallery/APIKeys.java
@@ -10,5 +10,6 @@ package com.example.samplegallery;
  * keys publically!
  */
 public class APIKeys {
-    public static final String FLICKR_API_KEY = "64ffdc1fd4b18211f4f98513848d2335";
+    // TODO: Change back to bogus key
+    public static final String FLICKR_API_KEY = "42abab5d4c80cdc5db2ea7a0a2df46b9";
 }

--- a/app/src/main/java/com/example/samplegallery/APIKeys.java
+++ b/app/src/main/java/com/example/samplegallery/APIKeys.java
@@ -10,5 +10,5 @@ package com.example.samplegallery;
  * keys publically!
  */
 public class APIKeys {
-    public static final String FLICKR_API_KEY = "64ffdc1fd4b18211f4f98513848d2335";
+    public static final String FLICKR_API_KEY = "42abab5d4c80cdc5db2ea7a0a2df46b9";
 }

--- a/app/src/main/java/com/example/samplegallery/PhotoBlowupFragment.java
+++ b/app/src/main/java/com/example/samplegallery/PhotoBlowupFragment.java
@@ -4,6 +4,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -34,7 +35,6 @@ public class PhotoBlowupFragment extends Fragment {
             throw new NullPointerException(
                     "PhotoBlowupFragment may not be invoked without photo information.");
         }
-
         photoID = b.getString("photoID");
     }
 
@@ -86,7 +86,8 @@ public class PhotoBlowupFragment extends Fragment {
                         try {
                             sizes = response.getJSONObject("sizes").getJSONArray("size");
                             photoUrl = sizes
-                                    .getJSONObject(sizes.length() - 1)
+                                    // for faster loading speeds, get a smaller image size
+                                    .getJSONObject(sizes.length() - 3)
                                     .getString("source");
                         } catch (JSONException e) {
                             e.printStackTrace();
@@ -104,7 +105,10 @@ public class PhotoBlowupFragment extends Fragment {
         photoSizesRequest.setTag(RequestTag);
         photoInfoRequest.setTag(RequestTag);
         VolleyRequestQueue.getInstance(getContext()).addToRequestQueue(photoInfoRequest);
+        // debugging
+        Log.d("ADD PHOTO INFO REQUEST", photoInfoRequest.toString());
         VolleyRequestQueue.getInstance(getContext()).addToRequestQueue(photoSizesRequest);
+        Log.d("ADD PHOTO SIZES REQUEST", photoSizesRequest.toString());
 
         return rootView;
     }

--- a/app/src/main/java/com/example/samplegallery/Utilities/LruBitmapCache.java
+++ b/app/src/main/java/com/example/samplegallery/Utilities/LruBitmapCache.java
@@ -44,6 +44,7 @@ class LruBitmapCache extends LruCache<String, Bitmap>
         final int screenBytes = screenHeight * screenWidth * 4;
 
         // 3 pages worth of images!
-        return screenBytes * 4;
+        // so, multiply by 3 --sean
+        return screenBytes * 3;
     }
 }

--- a/app/src/main/java/com/example/samplegallery/Utilities/VolleyRequestQueue.java
+++ b/app/src/main/java/com/example/samplegallery/Utilities/VolleyRequestQueue.java
@@ -28,7 +28,7 @@ public class VolleyRequestQueue {
                 new LruBitmapCache(LruBitmapCache.getCacheSize(context)));
     }
 
-    private RequestQueue getRequestQueue() {
+    public RequestQueue getRequestQueue() {
         if (reqQueue == null) {
             // mContext mustn't be null for the following instruction to execute.
             if (mContext == null) {

--- a/app/src/main/res/layout/photo_blowup_fragment.xml
+++ b/app/src/main/res/layout/photo_blowup_fragment.xml
@@ -3,15 +3,14 @@
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent" android:background="#dbdbdd">
 
-    <!--TROLOLO HUGE HACK! THE SPINNER NEVER STOPS SPINNING, BUT DOES GET COVERED UP! -->
-    <!--PERFORMANCE IS REALLY BAD HERE!-->
     <ProgressBar
+        android:id="@+id/progress_bar_blowup"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         style="@android:style/Widget.ProgressBar.Large"
         android:layout_centerInParent="true"/>
 
-    <com.android.volley.toolbox.NetworkImageView
+    <ImageView
         android:id="@+id/photo_blowup"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/test/java/com/example/samplegallery/Utilities/LruBitmapCacheTest.java
+++ b/app/src/test/java/com/example/samplegallery/Utilities/LruBitmapCacheTest.java
@@ -1,0 +1,42 @@
+package com.example.samplegallery.Utilities;
+
+import android.content.Context;
+import android.util.DisplayMetrics;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+
+/**
+ * Created by Sean Walker on 1/28/17.
+ */
+
+public class LruBitmapCacheTest {
+
+    @Mock
+    Context mMockContext;
+
+    @Test
+    public void getCacheSizeTest() {
+
+        // mock display metrics for the test
+        DisplayMetrics mockMetrics = new DisplayMetrics();
+        mockMetrics.widthPixels = 3;
+        mockMetrics.heightPixels = 3;
+
+        // mock chained events
+        mMockContext = Mockito.mock(Context.class, Mockito.RETURNS_DEEP_STUBS);
+        when(mMockContext.getResources().getDisplayMetrics()).thenReturn(mockMetrics);
+
+        // unit test with an assertion
+        // bytes = width * height * 4 * 3
+        assertThat(LruBitmapCache.getCacheSize(mMockContext), is(3 * 3 * 4 * 3));
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
I've written a UI test to test the synchronization of the photo, its title, and its description. I used the same VolleyQueueIdlingResource which was implemented in the sample UI test (https://github.com/YaleSTC/android_testing_training/tree/UITest). Afterwards, there are a few assertions ensuring that after navigating to the photo and blowing it up, the photo, its description, and title all appear together and the progress bar is hidden.